### PR TITLE
Cleans up deprecated call to Drupal::entityManager(). Tested on Drupal 8.9.17

### DIFF
--- a/src/EntityAutocompleteMatcher.php
+++ b/src/EntityAutocompleteMatcher.php
@@ -33,7 +33,7 @@ class EntityAutocompleteMatcher extends \Drupal\Core\Entity\EntityAutocompleteMa
         foreach ($values as $entity_id => $label) {
 
           $entity = \Drupal::entityTypeManager()->getStorage($target_type)->load($entity_id);
-          $entity = \Drupal::entityManager()->getTranslationFromContext($entity);
+          $entity = \Drupal::service('entity.repository')->getTranslationFromContext($entity);
 
           $type = !empty($entity->type->entity) ? $entity->type->entity->label() : $entity->bundle();
           $status = '';


### PR DESCRIPTION
Minnur, 

Thanks for your alter autocomplete blog post, and for posting the example to github!

This patch replaces a deprecated call to Drupal::entityManager()->getTranslationFromContext() and replaces it with a call to the entity.repository service method of the same name; \Drupal::service('entity.repository')->getTranslationFromContext()

After this example worked out so well for me I'll be digging a lot deeper into [downloads.minnur.com](https://downloads.minnur.com/)!

-Dan